### PR TITLE
Added Support for AOS-Soulbound, Made HP moniker configurable

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -14,6 +14,9 @@
 	"damage-log.new": "New",
 	"damage-log.diff": "Diff",
 
+	"damage-log.standardName" : "HP",
+	"damage-log.aosName" : "Toughness",
+
 	"damage-log.settings.use-tab": "Use separate damage log tab",
 	"damage-log.settings.use-tab-hint": "Use a separate tab for damage logs.  If this is unchecked, damage logs will be sent to the default chatlog.",
 

--- a/module.json
+++ b/module.json
@@ -35,7 +35,8 @@
 		"D35E",
 		"pf1",
 		"pf2e",
-		"worldbuilding"
+		"worldbuilding",
+		"age-of-sigmar-soulbound"
 	],
 	"url": "This is auto replaced",
 	"manifest": "This is auto replaced",

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -180,6 +180,7 @@ class DamageLog {
 
 		let oldTemp = 0, newTemp = 0;
 		let oldValue = 0, newValue = 0;
+		let hpName = game.i18n.localize("damage-log.standardName");
 		switch (game.system.id)
 		{
 			case "dnd5e":
@@ -208,6 +209,15 @@ class DamageLog {
 				break;
 			}
 
+			case "age-of-sigmar-soulbound":
+				hpName = game.i18n.localize("damage-log.aosName");
+				const oldHp = actor.combat.health.toughness;
+				const newHp = updateData.data?.combat.health.toughness;
+
+				oldValue = oldHp.value ?? 0;
+				newValue = newHp.value ?? 0;
+				break;
+
 			default:
 				return;
 		}
@@ -221,7 +231,7 @@ class DamageLog {
 		const flags = {
 			speaker,
 			temp: { old: oldTemp, new: newTemp, diff: tempDiff },
-			value: { old: oldValue, new: newValue, diff: valueDiff }
+			value: { name: hpName, old: oldValue, new: newValue, diff: valueDiff }
 		};
 
 		// There is a bug in Foundry 0.8.8 that causes preUpdateActor to fire multiple times.
@@ -445,6 +455,15 @@ class DamageLog {
 				update = {
 					"data.health.value": Math.min(currentHp.max, Math.max(currentHp.value - (flags.value.diff * modifier), currentHp.min))
 				};
+				break;
+			}
+
+			case "age-of-sigmar-soulbound":
+			{
+				const currentToughness = actorData.data.combat.health.toughness;
+				update = {
+					"data.combat.health.toughness.value" : Math.min(currentToughness.max, currentToughness.value - (flags.value.diff * modifier))
+				}
 				break;
 			}
 

--- a/templates/damage-log-table.hbs
+++ b/templates/damage-log-table.hbs
@@ -30,7 +30,7 @@
     {{#with value}}
     {{#if diff }}
     <tr>
-        <td>HP</td>
+        <td>{{name}}</td>
         <td class="num">{{old}}</td>
         <td class="num">{{numberFormat diff sign=true}}</td>
         <td class="num">{{new}}</td>


### PR DESCRIPTION
Module now Works for the Toughness HP Stat in the Age of Sigmar Soulbound System.
Gamesystem implementers can now set the Name for their HP Stat for their system.