### PR TITLE
Add 13th age system support and german locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Damage Log is current compatible with the following systems.
 * Simple Worldbuilding (`worldbuilding`)
 * Savage Worlds Adventure Edition (`swade`)
 * Tormenta 20 (`tormenta20`)
+* Toolkit13 (13th Age Compatible) (`archmage`)
 
 ## Installation
 Damage Log can be installed using the Foundry module installer.  Alternatively, you can install it using the following manifest URL...<br>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Damage Log is also compatible with the [Tabbed Chatlog](https://github.com/cswen
 * Integrates with the [Tabbed Chatlog](https://github.com/cswendrowski/FoundryVTT-Tabbed-Chatlog) module.  Damage Log's extra tab will be added on to the end of Tabbed Chatlog's tabs.
 
 ## System Compatibility
-Damage Log is current compatible with the following systems.
+Damage Log is currently compatible with the following systems.
 * Age of Sigmar: Soulbound (`age-of-sigmar-soulbound`)
 * Dungeons & Dragons v3.5 (`D35E`)
 * Dungeons & Dragons 5th Edition (`dnd5e`)

--- a/lang/de.json
+++ b/lang/de.json
@@ -1,0 +1,32 @@
+{
+	"damage-log.chat-tab-name": "Chat",
+	"damage-log.damage-log-tab-name": "Schadenslog",
+
+	"damage-log.reset-visibility": "Sichtbarkeit zurücksetzen",
+	"damage-log.undo-damage": "Schaden rückgängig",
+	"damage-log.undo-healing": "Heilung rückgängig",
+	"damage-log.redo-damage": "Schaden wiederholen",
+	"damage-log.redo-healing": "Heilung wiederholen",
+
+	"damage-log.damage-flavor-text": "Hat {diff} {damageType} Schaden genommen",
+	"damage-log.healing-flavor-text": "Wurde um {diff} geheilt",
+
+	"damage-log.old": "Alt",
+	"damage-log.new": "Neu",
+	"damage-log.diff": "Diff",
+
+	"damage-log.default.hp-name" : "TP",
+	"damage-log.default.temp-name" : "Temp",
+
+	"damage-log.settings.none": "Nichts",
+	"damage-log.settings.limited": "Beschränkt",
+	"damage-log.settings.observer": "Beobachter",
+	"damage-log.settings.owner": "Besitzer",
+
+	"damage-log.error.system-not-supported": "Damage Log | Das System '{systemId}' wird momentan nicht unterstützt",
+	"damage-log.error.scene-id-missing": "Damage Log | Szenen-ID fehlt im Schadenslog",
+	"damage-log.error.scene-deleted": "Damage Log | Szene '{scene}' existiert nicht mehr",
+	"damage-log.error.token-id-missing": "Damage Log | Spielfigur-ID fehlt im Schadenslog",
+	"damage-log.error.token-deleted": "Damage Log | Spielfigur '{token}' existiert nicht mehr",
+	"damage-log.error.no-undo-user": "Damage Log | Fehler: {undo} {damage}. Weder {user}, noch GM sind online"
+}

--- a/module.json
+++ b/module.json
@@ -36,7 +36,8 @@
 		"tormenta20",
 		"pf1",
 		"pf2e",
-		"worldbuilding"
+		"worldbuilding",
+		"archmage"
 	],
 	"relationships": {
 		"requires": [
@@ -51,7 +52,8 @@
 			{ "id": "tormenta20", "type": "system" },
 			{ "id": "pf1", "type": "system" },
 			{ "id": "pf2e", "type": "system" },
-			{ "id": "worldbuilding", "type": "system" }
+			{ "id": "worldbuilding", "type": "system" },
+			{ "id": "archmage", "type": "system"}
 		]
 	},
 	"esmodules": [

--- a/module.json
+++ b/module.json
@@ -71,6 +71,11 @@
 			"lang": "en",
 			"name": "English",
 			"path": "lang/en.json"
+		},
+		{
+			"lang": "de",
+			"name": "Deutsch",
+			"path": "lang/de.json"
 		}
 	],
 	"url": "#{URL}#",

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
 	"name": "damage-log",
 	"type": "module",
 	"title": "Damage Log",
-	"description": "Displayes damage and healing to tokens in a separate chatlog tab.",
+	"description": "Displays damage and healing to tokens in a separate chatlog tab.",
 	"version": "#{VERSION}#",
 	"library": false,
 	"manifestPlusVersion": "1.2.0",

--- a/scripts/damage-log.js
+++ b/scripts/damage-log.js
@@ -103,7 +103,8 @@ class DamageLog {
 				value: "combat.health.toughness.value",
 				max: "combat.health.toughness.max"
 			}
-		}
+		},
+		archmage: DamageLog.DND_ATTRIBUTES
 	};
 
 	static TABS_TEMPLATE = "modules/damage-log/templates/damage-log-tabs.hbs";


### PR DESCRIPTION
- Add support for the 13th Age Roleplaying System ([toolkit13](https://foundryvtt.com/packages/archmage), ID `archmage`) - very simple, as it has 5E compat
- Add german locale (excluding settings and system specific strings)
- Fix small typos

Thanks for this lifesaver of a module @cs96and!  
 As one of my groups is switching from 5E to 13th Age, I missed it enough to add support.