### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1,28 +1,22 @@
 {
 	"damage-log.chat-tab-name": "Chat",
 	"damage-log.damage-log-tab-name": "Schadenslog",
-
 	"damage-log.reset-visibility": "Sichtbarkeit zurücksetzen",
 	"damage-log.undo-damage": "Schaden rückgängig",
 	"damage-log.undo-healing": "Heilung rückgängig",
 	"damage-log.redo-damage": "Schaden wiederholen",
 	"damage-log.redo-healing": "Heilung wiederholen",
-
 	"damage-log.damage-flavor-text": "Hat {diff} {damageType} Schaden genommen",
 	"damage-log.healing-flavor-text": "Wurde um {diff} geheilt",
-
 	"damage-log.old": "Alt",
 	"damage-log.new": "Neu",
-	"damage-log.diff": "Diff",
-
-	"damage-log.default.hp-name" : "TP",
-	"damage-log.default.temp-name" : "Temp",
-
+	"damage-log.diff": "Unterschied",
+	"damage-log.default.hp-name": "TP",
+	"damage-log.default.temp-name": "Temporär",
 	"damage-log.settings.none": "Nichts",
 	"damage-log.settings.limited": "Beschränkt",
 	"damage-log.settings.observer": "Beobachter",
 	"damage-log.settings.owner": "Besitzer",
-
 	"damage-log.error.system-not-supported": "Damage Log | Das System '{systemId}' wird momentan nicht unterstützt",
 	"damage-log.error.scene-id-missing": "Damage Log | Szenen-ID fehlt im Schadenslog",
 	"damage-log.error.scene-deleted": "Damage Log | Szene '{scene}' existiert nicht mehr",

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -18,7 +18,7 @@
 	"damage-log.swade.fatigue-name": "Fatiga",
 	"damage-log.swade.bennies-name": "Bennies",
 	"damage-log.tormenta20.pv-name": "PV",
-	"damage-log.settings.use-tab": "Use a guia de registro de danos separada",
+	"damage-log.settings.use-tab": "Use a guia de log de danos separada",
 	"damage-log.settings.allow-player-view": "Permitir que os jogadores visualizem o log de danos",
 	"damage-log.settings.min-player-permission": "Permissão mínima do ator",
 	"damage-log.settings.allow-player-undo": "Permitir que os jogadores desfaçam/refaçam danos",
@@ -43,6 +43,6 @@
 	"damage-log.error.no-undo-user": "Log de Danos | Não é possível {desfazer} {dano}. Nem {user}, nem qualquer GM está conectado",
 	"damage-log.damage-log-tab-name": "Log de Danos",
 	"damage-log.healing-flavor-text": "Curou {diff} de dano",
-	"damage-log.settings.use-tab-hint": "Use uma guia separada para registros de danos. Se esta opção estiver desmarcada, os logs de danos serão enviados para o chatlog padrão.",
-	"damage-log.settings.min-player-permission-hint": "Os jogadores só poderão ver os atores no registro de danos para os quais eles têm essa permissão (ou melhor)."
+	"damage-log.settings.use-tab-hint": "Use uma guia separada para logs de danos. Se esta opção estiver desmarcada, os logs de danos serão enviados para o chatlog padrão.",
+	"damage-log.settings.min-player-permission-hint": "Os jogadores só poderão ver os atores no log de danos para os quais eles têm essa permissão (ou melhor)."
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Damage Log/main](https://weblate.foundryvtt-hub.com/projects/damage-log/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/damage-log/-/main/horizontal-auto.svg)