### PR TITLE
Add support for SW5e

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Damage Log is currently compatible with the following systems.
 * GURPS 4th Edition Game Aid (Unofficial) (`gurps`)
 * Pathfinder 1st Edition (`pf1`)
 * Pathfinder 2nd Edition (`pf2e`)
-* Simple Worldbuilding (`worldbuilding`)
 * Savage Worlds Adventure Edition (`swade`)
+* Simple Worldbuilding (`worldbuilding`)
 * Story Shaper (`shaper`)
-* Tormenta 20 (`tormenta20`)
 * Toolkit13 (13th Age Compatible) (`archmage`)
+* Tormenta 20 (`tormenta20`)
 
 ## Installation
 Damage Log can be installed using the Foundry module installer.  Alternatively, you can install it using the following manifest URL...<br>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Damage Log is currently compatible with the following systems.
 * Pathfinder 2nd Edition (`pf2e`)
 * Savage Worlds Adventure Edition (`swade`)
 * Simple Worldbuilding (`worldbuilding`)
+* Star Wars 5e (`sw5e`)
 * Story Shaper (`shaper`)
 * Toolkit13 (13th Age Compatible) (`archmage`)
 * Tormenta 20 (`tormenta20`)

--- a/module.json
+++ b/module.json
@@ -81,6 +81,10 @@
 				"type": "system"
 			},
 			{
+				"id": "sw5e",
+				"type": "system"
+			},
+			{
 				"id": "swade",
 				"type": "system"
 			},

--- a/module.json
+++ b/module.json
@@ -53,6 +53,10 @@
 				"type": "system"
 			},
 			{
+				"id": "archmage",
+				"type": "system"
+			},
+			{
 				"id": "D35E",
 				"type": "system"
 			},
@@ -65,14 +69,6 @@
 				"type": "system"
 			},
 			{
-				"id": "swade",
-				"type": "system"
-			},
-			{
-				"id": "tormenta20",
-				"type": "system"
-			},
-			{
 				"id": "pf1",
 				"type": "system"
 			},
@@ -81,18 +77,22 @@
 				"type": "system"
 			},
 			{
-				"id": "worldbuilding",
-				"type": "system"
-			},
-			{
-				"id": "archmage",
-				"type": "system"
-			},
-			{
 				"id": "shaper",
 				"type": "system"
+			},
+			{
+				"id": "swade",
+				"type": "system"
+			},
+			{
+				"id": "tormenta20",
+				"type": "system"
+			},
+			{
+				"id": "worldbuilding",
+				"type": "system"
 			}
-		]
+]
 	},
 	"esmodules": [
 		"scripts/damage-log.js",

--- a/scripts/damage-log.js
+++ b/scripts/damage-log.js
@@ -89,6 +89,7 @@ class DamageLog {
 				max: "attributes.hp.max"
 			}
 		},
+		sw5e: DamageLog.DND_ATTRIBUTES,
 		swade: {
 			wounds: {
 				invert: true,

--- a/scripts/damage-log.js
+++ b/scripts/damage-log.js
@@ -40,7 +40,13 @@ class DamageLog {
 	 * Location of HP attributes for supported systems.
 	 */
 	static SYSTEM_CONFIGS = {
-		dnd5e: DamageLog.DND_ATTRIBUTES,
+		"age-of-sigmar-soulbound": {
+			toughness: {
+				value: "combat.health.toughness.value",
+				max: "combat.health.toughness.max"
+			}
+		},
+		archmage: DamageLog.DND_ATTRIBUTES,
 		D35E: mergeObject(DamageLog.DND_ATTRIBUTES, {
 			vigor: {
 				value: "attributes.vigor.value",
@@ -56,13 +62,7 @@ class DamageLog {
 				max: "attributes.wounds.max"
 			}
 		}),
-		pf1: DamageLog.DND_ATTRIBUTES,
-		pf2e: mergeObject(DamageLog.DND_ATTRIBUTES, {
-			sp: {
-				value: "attributes.sp.value",
-				max: "attributes.sp.max"
-			}
-		}),
+		dnd5e: DamageLog.DND_ATTRIBUTES,
 		gurps: {
 			hp: {
 				value: "HP.value",
@@ -73,6 +73,20 @@ class DamageLog {
 				value: "FP.value",
 				min: "FP.min",
 				max: "FP.max"
+			}
+		},
+		pf1: DamageLog.DND_ATTRIBUTES,
+		pf2e: mergeObject(DamageLog.DND_ATTRIBUTES, {
+			sp: {
+				value: "attributes.sp.value",
+				max: "attributes.sp.max"
+			}
+		}),
+		shaper: {
+			hp: {
+				value: "attributes.hp.value",
+				min: "attributes.hp.min",
+				max: "attributes.hp.max"
 			}
 		},
 		swade: {
@@ -110,20 +124,6 @@ class DamageLog {
 				value: "health.value",
 				min: "health.min",
 				max: "health.max"
-			}
-		},
-		"age-of-sigmar-soulbound": {
-			toughness: {
-				value: "combat.health.toughness.value",
-				max: "combat.health.toughness.max"
-			}
-		},
-		archmage: DamageLog.DND_ATTRIBUTES,
-		shaper: {
-			hp: {
-				value: "attributes.hp.value",
-				min: "attributes.hp.min",
-				max: "attributes.hp.max"
 			}
 		}
 	};


### PR DESCRIPTION
This:
* Sorts the supported systems alphabetically:
    * by name in the `README.md`
    * by system id in `module.json` and `damage-log.js`
* Adds support for the implementation of the [Star Wars 5e](https://sw5e.com/) system from [sw5e-foundry/sw5e](https://github.com/sw5e-foundry/sw5e).
